### PR TITLE
Optimize chat panel memory usage

### DIFF
--- a/client/src/config/constants.ts
+++ b/client/src/config/constants.ts
@@ -46,6 +46,8 @@ export const THEME_CONFIG = {
 export const CHAT_CONFIG = {
   MAX_MESSAGE_LENGTH: 2000,
   MAX_HISTORY_SIZE: 100,
+  MAX_RENDERED_MESSAGES: 50,
+  API_HISTORY_LIMIT: 20,
   TYPING_DELAY: 1000,
   AUTO_SCROLL_BEHAVIOR: 'smooth' as ScrollBehavior,
   PLACEHOLDER_TEXT: 'データについて質問してください... (⌘+Enter で送信)',

--- a/client/src/features/chat/components/ChatMessage.tsx
+++ b/client/src/features/chat/components/ChatMessage.tsx
@@ -12,7 +12,7 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
-import { type FC } from 'react';
+import { type FC, memo, useMemo } from 'react';
 
 import MarkdownRenderer from '../../../components/markdown/MarkdownRenderer';
 import { formatTimestamp } from '../../../utils/date';
@@ -27,7 +27,7 @@ interface ChatMessageProps {
   isCreatingChart?: boolean;
 }
 
-export const ChatMessage: FC<ChatMessageProps> = ({
+const ChatMessageComponent: FC<ChatMessageProps> = ({
   message,
   onRequestPreview,
   onRequestChart,
@@ -35,7 +35,10 @@ export const ChatMessage: FC<ChatMessageProps> = ({
   isCreatingChart = false,
 }) => {
   const theme = useTheme();
-  const styles = createMessageStyles(theme, message.sender === 'user');
+  const styles = useMemo(() => createMessageStyles(theme, message.sender === 'user'), [
+    theme,
+    message.sender,
+  ]);
 
   return (
     <Box sx={styles.container}>
@@ -300,3 +303,5 @@ export const ChatMessage: FC<ChatMessageProps> = ({
     </Box>
   );
 };
+
+export const ChatMessage = memo(ChatMessageComponent);

--- a/client/src/features/chat/components/ChatPanel.tsx
+++ b/client/src/features/chat/components/ChatPanel.tsx
@@ -23,7 +23,7 @@ import {
   useTheme,
   Zoom,
 } from '@mui/material';
-import React, { type FC, useCallback, useEffect, useRef, useState } from 'react';
+import React, { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { CHAT_CONFIG } from '../../../config/constants';
 import { createChatPanelStyles } from '../styles/chatStyles';
@@ -146,12 +146,24 @@ export const ChatPanel: FC<ChatPanelProps> = ({
 }) => {
   const chatEndRef = useRef<HTMLDivElement | null>(null);
   const theme = useTheme();
-  const styles = createChatPanelStyles(theme);
+  const styles = useMemo(() => createChatPanelStyles(theme), [theme]);
   const [clearDialogOpen, setClearDialogOpen] = useState(false);
+
+  const visibleMessages = useMemo(() => {
+    const limit = CHAT_CONFIG.MAX_RENDERED_MESSAGES || CHAT_CONFIG.MAX_HISTORY_SIZE;
+    if (!limit || messages.length <= limit) {
+      return messages;
+    }
+
+    return messages.slice(-limit);
+  }, [messages]);
+
+  const hasHiddenHistory = messages.length > visibleMessages.length;
+  const hiddenCount = hasHiddenHistory ? messages.length - visibleMessages.length : 0;
 
   useEffect(() => {
     chatEndRef.current?.scrollIntoView({ behavior: CHAT_CONFIG.AUTO_SCROLL_BEHAVIOR });
-  }, [messages, isLoading]);
+  }, [visibleMessages, isLoading]);
 
   const handleSubmit = useCallback(() => {
     if (input.trim()) {
@@ -213,11 +225,21 @@ export const ChatPanel: FC<ChatPanelProps> = ({
           <ChatPreviewModal open={preview.isOpen} code={preview.code} onClose={onClosePreview} />
 
           <Box sx={styles.messagesContainer}>
-            {messages.length === 0 ? (
+            {hasHiddenHistory && (
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ display: 'block', textAlign: 'center', mb: 2 }}
+              >
+                最新 {visibleMessages.length} 件のメッセージを表示中。過去 {hiddenCount} 件は自動的に折りたたまれています。
+              </Typography>
+            )}
+
+            {visibleMessages.length === 0 ? (
               <EmptyState />
             ) : (
               <>
-                {messages.map((msg) => (
+                {visibleMessages.map((msg) => (
                   <ChatMessageComponent
                     key={msg.id}
                     message={msg}


### PR DESCRIPTION
## Summary
- cap chat history size and API payloads to reduce memory growth over long sessions
- render only the most recent chat messages and memoize message components to avoid unnecessary re-renders
- ensure pending chat requests are aborted on cancel/unmount to prevent lingering network work

## Testing
- CI=1 npm run build -- --logLevel warn

------
https://chatgpt.com/codex/tasks/task_e_68dc621a3c84832aa9ab7d06943532e7