### PR TITLE
Refine chat preview modal usage

### DIFF
--- a/client/src/features/chat/components/index.ts
+++ b/client/src/features/chat/components/index.ts
@@ -1,4 +1,3 @@
 export { ChatMessage } from './ChatMessage';
 export { ChatPanel } from './ChatPanel';
-export { ChatPreviewModal } from './ChatPreviewModal';
 export { LoadingIndicator } from './LoadingIndicator';

--- a/client/src/features/chat/index.ts
+++ b/client/src/features/chat/index.ts
@@ -1,4 +1,4 @@
-export { ChatPanel, ChatPreviewModal, LoadingIndicator } from './components';
+export { ChatPanel, LoadingIndicator } from './components';
 export { ChatMessage as ChatMessageComponent } from './components';
 export * from './hooks/useChat';
 export { createChatPanelStyles, createMessageStyles } from './styles/chatStyles';

--- a/client/src/pages/PerformancePage.tsx
+++ b/client/src/pages/PerformancePage.tsx
@@ -1,7 +1,7 @@
 import { Box, useTheme } from '@mui/material';
 
 import { tableauUserName } from '../config/tableau';
-import { ChatPanel, ChatPreviewModal } from '../features/chat/components';
+import { ChatPanel } from '../features/chat/components';
 import { useChat } from '../features/chat/hooks/useChat';
 import { TableauDashboard } from '../features/tableau/components';
 import { JWTPageWrapper } from './components';
@@ -40,12 +40,6 @@ const PerformancePage = () => {
           onClearMessages={chatHook.clearMessages}
         />
 
-        {/* チャットプレビューモーダル */}
-        <ChatPreviewModal
-          open={chatHook.preview.isOpen}
-          code={chatHook.preview.code}
-          onClose={chatHook.closePreview}
-        />
       </Box>
     </JWTPageWrapper>
   );


### PR DESCRIPTION
## Summary
- rely on ChatPanel's integrated ChatPreviewModal
- remove duplicate preview modal rendering from PerformancePage
- tidy chat module exports to match the single-modal approach

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc69e5fdcc832a88ffade2164eb39f