### PR TITLE
Refactor chat preview caching

### DIFF
--- a/client/src/features/chat/components/ChatMessage.tsx
+++ b/client/src/features/chat/components/ChatMessage.tsx
@@ -25,6 +25,8 @@ interface ChatMessageProps {
   onRequestChart: (message: ChatMessageType) => void;
   isCreatingReport?: boolean;
   isCreatingChart?: boolean;
+  previewAvailable: boolean;
+  chartCode?: string | null;
 }
 
 export const ChatMessage: FC<ChatMessageProps> = ({
@@ -33,6 +35,8 @@ export const ChatMessage: FC<ChatMessageProps> = ({
   onRequestChart,
   isCreatingReport = false,
   isCreatingChart = false,
+  previewAvailable,
+  chartCode,
 }) => {
   const theme = useTheme();
   const styles = createMessageStyles(theme, message.sender === 'user');
@@ -130,7 +134,7 @@ export const ChatMessage: FC<ChatMessageProps> = ({
           <Box sx={styles.actionButtons}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <Tooltip
-                title={message.dashboardCode ? 'レポート再表示' : 'レポート作成'}
+                title={previewAvailable ? 'レポート再表示' : 'レポート作成'}
                 placement="top"
                 arrow
               >
@@ -139,15 +143,15 @@ export const ChatMessage: FC<ChatMessageProps> = ({
                   onClick={() => onRequestPreview(message)}
                   disabled={isCreatingReport}
                   sx={{
-                    color: message.dashboardCode ? '#10b981' : '#3b82f6',
+                    color: previewAvailable ? '#10b981' : '#3b82f6',
                     backgroundColor: 'rgba(59, 130, 246, 0.05)',
                     border: '1px solid',
-                    borderColor: message.dashboardCode ? '#10b981' : '#3b82f6',
+                    borderColor: previewAvailable ? '#10b981' : '#3b82f6',
                     '&:hover': {
-                      backgroundColor: message.dashboardCode
+                      backgroundColor: previewAvailable
                         ? 'rgba(16, 185, 129, 0.1)'
                         : 'rgba(59, 130, 246, 0.1)',
-                      borderColor: message.dashboardCode ? '#059669' : '#2563eb',
+                      borderColor: previewAvailable ? '#059669' : '#2563eb',
                       transform: 'scale(1.05)',
                     },
                     '&:disabled': {
@@ -164,7 +168,7 @@ export const ChatMessage: FC<ChatMessageProps> = ({
 
               <Tooltip
                 title={
-                  message.chartCode
+                  chartCode
                     ? message.showChart
                       ? 'チャート非表示'
                       : 'チャート表示'
@@ -178,25 +182,25 @@ export const ChatMessage: FC<ChatMessageProps> = ({
                   onClick={() => onRequestChart(message)}
                   disabled={isCreatingChart}
                   sx={{
-                    color: message.chartCode
+                    color: chartCode
                       ? message.showChart
                         ? '#f59e0b'
                         : '#10b981'
                       : '#8b5cf6',
                     backgroundColor: 'rgba(139, 92, 246, 0.05)',
                     border: '1px solid',
-                    borderColor: message.chartCode
+                    borderColor: chartCode
                       ? message.showChart
                         ? '#f59e0b'
                         : '#10b981'
                       : '#8b5cf6',
                     '&:hover': {
-                      backgroundColor: message.chartCode
+                      backgroundColor: chartCode
                         ? message.showChart
                           ? 'rgba(245, 158, 11, 0.1)'
                           : 'rgba(16, 185, 129, 0.1)'
                         : 'rgba(139, 92, 246, 0.1)',
-                      borderColor: message.chartCode
+                      borderColor: chartCode
                         ? message.showChart
                           ? '#d97706'
                           : '#059669'
@@ -258,7 +262,7 @@ export const ChatMessage: FC<ChatMessageProps> = ({
           </Box>
         )}
 
-        {message.sender === 'bot' && message.showChart && message.chartCode && (
+        {message.sender === 'bot' && message.showChart && chartCode && (
           <Box sx={styles.chartContainer}>
             <Box sx={styles.chartHeader}>
               <Typography
@@ -277,7 +281,7 @@ export const ChatMessage: FC<ChatMessageProps> = ({
             </Box>
             <Box sx={styles.chartFrame}>
               <iframe
-                srcDoc={message.chartCode}
+                srcDoc={chartCode}
                 style={{
                   width: '100%',
                   height: '100%',

--- a/client/src/features/chat/components/ChatPanel.tsx
+++ b/client/src/features/chat/components/ChatPanel.tsx
@@ -48,6 +48,8 @@ interface ChatPanelProps {
   onClosePreview: () => void;
   onCancelMessage?: () => void;
   onClearMessages?: () => void;
+  getPreviewContent: (messageId: number | null) => string | undefined;
+  getChartContent: (messageId: number) => string | undefined;
 }
 
 const EmptyState: FC = () => {
@@ -143,6 +145,8 @@ export const ChatPanel: FC<ChatPanelProps> = ({
   onClosePreview,
   onCancelMessage,
   onClearMessages,
+  getPreviewContent,
+  getChartContent,
 }) => {
   const chatEndRef = useRef<HTMLDivElement | null>(null);
   const theme = useTheme();
@@ -210,7 +214,11 @@ export const ChatPanel: FC<ChatPanelProps> = ({
             </Box>
           </Paper>
 
-          <ChatPreviewModal open={preview.isOpen} code={preview.code} onClose={onClosePreview} />
+          <ChatPreviewModal
+            open={preview.isOpen}
+            code={getPreviewContent(preview.messageId) ?? null}
+            onClose={onClosePreview}
+          />
 
           <Box sx={styles.messagesContainer}>
             {messages.length === 0 ? (
@@ -225,6 +233,8 @@ export const ChatPanel: FC<ChatPanelProps> = ({
                     onRequestChart={onRequestChart}
                     isCreatingReport={isCreatingReport}
                     isCreatingChart={isCreatingChart}
+                    previewAvailable={Boolean(getPreviewContent(msg.id))}
+                    chartCode={getChartContent(msg.id) ?? null}
                   />
                 ))}
                 {isLoading && <LoadingMessage onCancel={onCancelMessage} />}

--- a/client/src/features/chat/types.ts
+++ b/client/src/features/chat/types.ts
@@ -5,14 +5,12 @@ export interface ChatMessage {
   text: string;
   sender: ChatSender;
   timestamp: string;
-  dashboardCode?: string;
-  chartCode?: string;
   showChart?: boolean;
 }
 
 export interface ChatPreviewState {
   isOpen: boolean;
-  code: string | null;
+  messageId: number | null;
 }
 
 export interface ChatHookState {

--- a/client/src/pages/PerformancePage.tsx
+++ b/client/src/pages/PerformancePage.tsx
@@ -38,12 +38,14 @@ const PerformancePage = () => {
           onClosePreview={chatHook.closePreview}
           onCancelMessage={chatHook.cancelMessage}
           onClearMessages={chatHook.clearMessages}
+          getPreviewContent={chatHook.getPreviewContent}
+          getChartContent={chatHook.getChartContent}
         />
 
         {/* チャットプレビューモーダル */}
         <ChatPreviewModal
           open={chatHook.preview.isOpen}
-          code={chatHook.preview.code}
+          code={chatHook.getPreviewContent(chatHook.preview.messageId) ?? null}
           onClose={chatHook.closePreview}
         />
       </Box>


### PR DESCRIPTION
## Summary
- remove inline HTML payloads from chat messages and track preview state by message ID
- cache generated preview and chart HTML outside of chat messages and manage lifecycle
- update chat components to read preview/chart HTML from the cache when rendering

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc6c129a9c832aa83416f14d7b7593