### PR TITLE
Fix chat preview modal import and cleanup

### DIFF
--- a/client/src/features/chat/components/index.ts
+++ b/client/src/features/chat/components/index.ts
@@ -1,3 +1,4 @@
 export { ChatMessage } from './ChatMessage';
 export { ChatPanel } from './ChatPanel';
+export { ChatPreviewModal } from './ChatPreviewModal';
 export { LoadingIndicator } from './LoadingIndicator';

--- a/client/src/features/chat/hooks/useChat.ts
+++ b/client/src/features/chat/hooks/useChat.ts
@@ -44,15 +44,6 @@ interface CreateChartResponse {
   success: boolean;
 }
 
-const trimMessages = (messages: ChatMessage[]): ChatMessage[] => {
-  const limit = CHAT_CONFIG.MAX_HISTORY_SIZE;
-  if (!limit || messages.length <= limit) {
-    return messages;
-  }
-
-  return messages.slice(-limit);
-};
-
 export const useChat = () => {
   const [state, setState] = useState<ChatHookState>({
     messages: [],

--- a/client/src/pages/PerformancePage.tsx
+++ b/client/src/pages/PerformancePage.tsx
@@ -1,7 +1,7 @@
 import { Box, useTheme } from '@mui/material';
 
 import { tableauUserName } from '../config/tableau';
-import { ChatPanel } from '../features/chat/components';
+import { ChatPanel, ChatPreviewModal } from '../features/chat/components';
 import { useChat } from '../features/chat/hooks/useChat';
 import { TableauDashboard } from '../features/tableau/components';
 import { JWTPageWrapper } from './components';


### PR DESCRIPTION
## Summary
- re-export ChatPreviewModal in the chat components barrel and use the shared import on the performance page
- remove an unused helper from useChat to satisfy TypeScript

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc7e7d1984832a86c2f94c1d9b83b7