### PR TITLE
Align server Python requirement with README guidance

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -3,7 +3,7 @@ name = "server"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 dependencies = [
     "anthropic[bedrock]>=0.67.0",
     "fastapi[standard]>=0.116.1",

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
## Summary
- update the server package's minimum Python version to 3.11 in both the project configuration and lock file so it matches the documented requirement

## Testing
- uv sync --python python3.11 *(fails: unable to download python-build-standalone artifact due to tunnel connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7e7f9dec832a8e63e35e33c802b1