### PR TITLE
Use standard AWS credential env vars

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,7 +1,7 @@
 # AWS Bedrock Configuration
 AWS_REGION=ap-northeast-1
-AWS_ACCESS_KEY=your_aws_access_key_here
-AWS_SECRET_KEY=your_aws_secret_key_here
+AWS_ACCESS_KEY_ID=your_aws_access_key_here
+AWS_SECRET_ACCESS_KEY=your_aws_secret_key_here
 AWS_SESSION_TOKEN=your_aws_session_token_here
 
 # Bedrock Model Configuration

--- a/server/app/config/settings.py
+++ b/server/app/config/settings.py
@@ -68,8 +68,8 @@ class Settings(BaseModel):
         super().__init__(
             aws=AWSSettings(
                 region=os.getenv("AWS_REGION", "ap-northeast-1"),
-                access_key=os.getenv("AWS_ACCESS_KEY"),
-                secret_key=os.getenv("AWS_SECRET_KEY"),
+                access_key=os.getenv("AWS_ACCESS_KEY_ID"),
+                secret_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
                 session_token=os.getenv("AWS_SESSION_TOKEN")
             ),
             bedrock=BedrockSettings(


### PR DESCRIPTION
## Summary
- load AWS credentials from the standard AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables
- update the backend .env example to reflect the new variable names

## Testing
- uv run uvicorn app.main:app --reload

------
https://chatgpt.com/codex/tasks/task_e_68dc7e80937c832ab1a274de1cbd890f